### PR TITLE
Add minor UX enhancements

### DIFF
--- a/autoloads/app.gd
+++ b/autoloads/app.gd
@@ -13,6 +13,11 @@ func _ready() -> void:
 	preferences.load(Constants.PREFERENCES_PATH)
 
 
+func _shortcut_input(event: InputEvent) -> void:
+	if event.is_action_pressed("Add node"):
+		GlobalSignal.emit("enable_picker_mode")
+
+
 func update_window(update_size: bool = false):
 	var screen_size = DisplayServer.window_get_size()
 	var scale_factor: float = get_auto_display_scale()

--- a/autoloads/app.gd
+++ b/autoloads/app.gd
@@ -3,11 +3,14 @@ extends Node
 
 # The DPI of a 23.8 inch display with a 1920x1080 resolution
 const BASE_SCALE_DPI = 92.56
+# Application preferences
+var preferences := ConfigFile.new()
 
 
 func _ready() -> void:
 	update_window(true)
 	get_window().connect("size_changed", update_window)
+	preferences.load(Constants.PREFERENCES_PATH)
 
 
 func update_window(update_size: bool = false):

--- a/autoloads/constants.gd
+++ b/autoloads/constants.gd
@@ -21,6 +21,8 @@ const NODE_SCENES = {
 	"Wait": preload("res://nodes/wait_node/wait_node.tscn"),
 	"Reroute": preload("res://nodes/reroute_node/reroute_node.tscn")
 }
+const HISTORY_PATH = "user://history.save"
+const PREFERENCES_PATH = "user://preferences.cfg"
 const PROPERTY_CLASSES = ["Property", "Localizable"]
 const UNSAVED_FILE_SUFFIX: String = "*"
 

--- a/common/layouts/graph_edit/monologue_graph_edit.gd
+++ b/common/layouts/graph_edit/monologue_graph_edit.gd
@@ -372,9 +372,11 @@ func _on_connection_to_empty(node: String, port: int, release: Vector2) -> void:
 	GlobalSignal.emit("enable_picker_mode", [node, port, release, graph_release, center])
 
 
-func _on_focus_entered() -> void:
-	# when the user focuses on the graph edit itself, close unnecessary stuff
-	GlobalSignal.emit("show_languages", [false])
+func _on_gui_input(event: InputEvent) -> void:
+	# when the user clicks on the graph edit, close unnecessary stuff
+	if event is InputEventMouseButton and event.is_pressed() and \
+			event.button_index == MOUSE_BUTTON_LEFT:
+		GlobalSignal.emit("show_languages", [false])
 
 
 func _on_node_selected(node) -> void:

--- a/common/layouts/graph_edit/monologue_graph_edit.gd
+++ b/common/layouts/graph_edit/monologue_graph_edit.gd
@@ -372,6 +372,11 @@ func _on_connection_to_empty(node: String, port: int, release: Vector2) -> void:
 	GlobalSignal.emit("enable_picker_mode", [node, port, release, graph_release, center])
 
 
+func _on_focus_entered() -> void:
+	# when the user focuses on the graph edit itself, close unnecessary stuff
+	GlobalSignal.emit("show_languages", [false])
+
+
 func _on_node_selected(node) -> void:
 	if node is MonologueGraphNode:
 		selected_nodes.append(node)

--- a/common/layouts/graph_edit/monologue_graph_edit.tscn
+++ b/common/layouts/graph_edit/monologue_graph_edit.tscn
@@ -31,7 +31,7 @@ script = ExtResource("1_ivjsb")
 [connection signal="connection_request" from="." to="." method="_on_connection_request"]
 [connection signal="connection_to_empty" from="." to="." method="_on_connection_to_empty"]
 [connection signal="disconnection_request" from="." to="." method="_on_disconnection_request"]
-[connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
+[connection signal="gui_input" from="." to="." method="_on_gui_input"]
 [connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]
 [connection signal="node_deselected" from="." to="." method="_on_node_deselected"]

--- a/common/layouts/graph_edit/monologue_graph_edit.tscn
+++ b/common/layouts/graph_edit/monologue_graph_edit.tscn
@@ -31,6 +31,7 @@ script = ExtResource("1_ivjsb")
 [connection signal="connection_request" from="." to="." method="_on_connection_request"]
 [connection signal="connection_to_empty" from="." to="." method="_on_connection_to_empty"]
 [connection signal="disconnection_request" from="." to="." method="_on_disconnection_request"]
+[connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
 [connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]
 [connection signal="node_deselected" from="." to="." method="_on_node_deselected"]

--- a/common/layouts/side_panel/side_panel.gd
+++ b/common/layouts/side_panel/side_panel.gd
@@ -8,6 +8,7 @@ class_name SidePanel extends PanelContainer
 @onready var ribbon_scene = preload("res://common/ui/ribbon/ribbon.tscn")
 @onready var collapsible_field = preload("res://common/ui/fields/collapsible_field/collapsible_field.tscn")
 
+var collapsibles: Dictionary[String, CollapsibleField]
 var id_field: MonologueField
 var selected_node: MonologueGraphNode
 
@@ -22,6 +23,7 @@ func clear():
 		field.free()
 	if is_instance_valid(id_field):
 		id_field.free()
+	collapsibles.clear()
 
 
 func on_graph_node_deselected(_node):
@@ -88,7 +90,8 @@ func on_graph_node_selected(node: MonologueGraphNode, bypass: bool = false):
 					if property.uncollapse:
 						field_obj.open()
 						property.uncollapse = false
-
+					collapsibles[field_name] = field_obj
+	
 	for property_name in property_names:
 		if property_name in already_invoke:
 			continue

--- a/common/layouts/side_panel/side_panel.gd
+++ b/common/layouts/side_panel/side_panel.gd
@@ -27,7 +27,7 @@ func clear():
 
 
 func on_graph_node_deselected(_node):
-	hide()
+	hide.call_deferred()
 
 
 func on_graph_node_selected(node: MonologueGraphNode, bypass: bool = false):
@@ -54,9 +54,10 @@ func on_graph_node_selected(node: MonologueGraphNode, bypass: bool = false):
 		elif focus_owner is LineEdit:
 			refocus_column = focus_owner.get_caret_column()
 	var uncollapse_paths: Array[NodePath] = []
-	for collapsible: CollapsibleField in collapsibles.values():
-		if collapsible.is_open():
-			uncollapse_paths.append(get_path_to(collapsible))
+	if node == selected_node:
+		for collapsible: CollapsibleField in collapsibles.values():
+			if collapsible.is_open():
+				uncollapse_paths.append(get_path_to(collapsible))
 	
 	clear()
 	selected_node = node

--- a/common/layouts/side_panel/side_panel.gd
+++ b/common/layouts/side_panel/side_panel.gd
@@ -53,6 +53,10 @@ func on_graph_node_selected(node: MonologueGraphNode, bypass: bool = false):
 			refocus_column = focus_owner.get_caret_column()
 		elif focus_owner is LineEdit:
 			refocus_column = focus_owner.get_caret_column()
+	var uncollapse_paths: Array[NodePath] = []
+	for collapsible: CollapsibleField in collapsibles.values():
+		if collapsible.is_open():
+			uncollapse_paths.append(get_path_to(collapsible))
 	
 	clear()
 	selected_node = node
@@ -103,6 +107,7 @@ func on_graph_node_selected(node: MonologueGraphNode, bypass: bool = false):
 			field.set_label_text(property_name.capitalize())
 
 	show()
+	restore_collapsible_state(uncollapse_paths)
 	# if focus was preserved, restore it
 	restore_focus(refocus_path, refocus_line, refocus_column)
 
@@ -115,6 +120,15 @@ func refocus(node: MonologueGraphNode) -> void:
 		if focus_owner:
 			focus_owner.release_focus()
 			focus_owner.grab_focus()
+
+
+## If any collapsible fields were opened before the side panel was refreshed,
+## this method will reopen them via their node paths.
+func restore_collapsible_state(uncollapse_paths: Array[NodePath]) -> void:
+	for path in uncollapse_paths:
+		var field = get_node_or_null(path)
+		if is_instance_valid(field) and field is CollapsibleField:
+			field.open()
 
 
 ## Hacky improvement for #52 to maintain focus on side panel refresh.

--- a/common/layouts/side_panel/side_panel.gd
+++ b/common/layouts/side_panel/side_panel.gd
@@ -19,10 +19,9 @@ func _ready():
 
 func clear():
 	for field in fields_container.get_children():
-		fields_container.remove_child(field)
-		field.queue_free()
+		field.free()
 	if is_instance_valid(id_field):
-		id_field.queue_free()
+		id_field.free()
 
 
 func on_graph_node_deselected(_node):

--- a/common/monologue_graph_node.gd
+++ b/common/monologue_graph_node.gd
@@ -54,7 +54,7 @@ func _update_slot_icons() -> void:
 
 func _harmonize_size() -> void:
 	size.x = ceil(size.x/30)*30
-	size.y = ceil(size.y/30)*30
+	size.y = get_combined_minimum_size().y
 
 
 func _set_titlebar_color(val: Color):

--- a/common/ui/fields/collapsible_field/collapsible_field.gd
+++ b/common/ui/fields/collapsible_field/collapsible_field.gd
@@ -22,7 +22,8 @@ func _ready() -> void:
 
 
 func add_item(item: Control, force_readable_name: bool = false) -> void:
-	if separate_items and vbox.get_children().size() > 0:
+	var existing_children = vbox.get_children().filter(_is_not_being_deleted)
+	if separate_items and existing_children.size() > 0:
 		vbox.add_child(HSeparator.new(), true)
 	
 	vbox.add_child(item, force_readable_name)
@@ -42,7 +43,6 @@ func is_open() -> bool:
 
 func clear() -> void:
 	for child in vbox.get_children():
-		vbox.remove_child(child)
 		child.queue_free()
 
 
@@ -65,3 +65,7 @@ func close() -> void:
 
 func _on_add_button_pressed() -> void:
 	add_pressed.emit()
+
+
+func _is_not_being_deleted(node: Node) -> bool:
+	return not node.is_queued_for_deletion()

--- a/common/ui/fields/collapsible_field/collapsible_field.gd
+++ b/common/ui/fields/collapsible_field/collapsible_field.gd
@@ -23,7 +23,7 @@ func _ready() -> void:
 
 func add_item(item: Control, force_readable_name: bool = false) -> void:
 	if separate_items and vbox.get_children().size() > 0:
-		vbox.add_child(HSeparator.new())
+		vbox.add_child(HSeparator.new(), true)
 	
 	vbox.add_child(item, force_readable_name)
 

--- a/common/ui/fields/collapsible_field/collapsible_field.gd
+++ b/common/ui/fields/collapsible_field/collapsible_field.gd
@@ -36,6 +36,10 @@ func get_items() -> Array[Node]:
 	return vbox.get_children().filter(func(c): return c is not HSeparator)
 
 
+func is_open() -> bool:
+	return collapsible_container.visible
+
+
 func clear() -> void:
 	for child in vbox.get_children():
 		vbox.remove_child(child)
@@ -43,7 +47,7 @@ func clear() -> void:
 
 
 func _on_button_pressed() -> void:
-	if collapsible_container.visible:
+	if is_open():
 		close()
 	else:
 		open()

--- a/common/ui/fields/dropdown/monolgue_dropdown.gd
+++ b/common/ui/fields/dropdown/monolgue_dropdown.gd
@@ -68,7 +68,7 @@ func validate():
 	var is_out = option_button.selected >= option_button.item_count
 	var is_negative = option_button.selected < 0
 	if is_negative or is_out or option_button.is_item_disabled(option_button.selected):
-		var stylebox = load("res://Assets/DropdownError.stylebox")
+		var stylebox = load("res://ui/theme_default/dropdown_error.stylebox")
 		option_button.add_theme_color_override("font_hover_color", Color("c42e40"))
 		option_button.add_theme_color_override("font_focus_color", Color("8b0000"))
 		option_button.add_theme_color_override("font_color", Color("8b0000"))

--- a/common/ui/fields/property.gd
+++ b/common/ui/fields/property.gd
@@ -86,7 +86,7 @@ func show(panel: Control, child_index: int = -1) -> MonologueField:
 	for property in setters.keys():
 		field.set(property, setters.get(property))
 	
-	panel.add_child(field)
+	panel.add_child(field, true)
 	if child_index >= 0:
 		panel.move_child(field, child_index)
 	

--- a/common/ui/fields/spin_box/monologue_spin_box.gd
+++ b/common/ui/fields/spin_box/monologue_spin_box.gd
@@ -1,6 +1,7 @@
 class_name MonologueSpinBox extends MonologueField
 
 
+@export var as_integer: bool = true
 @export var minimum: float = -9999999999
 @export var maximum: float = 9999999999
 @export var step: float = 1
@@ -31,12 +32,15 @@ func propagate(value: Variant) -> void:
 
 
 func _on_focus_exited() -> void:
-	_on_text_submitted(spin_box.value)
+	_on_text_submitted(int(spin_box.value) if as_integer else spin_box.value)
 
 
 func _on_text_submitted(_new_value: Variant) -> void:
-	field_updated.emit(spin_box.value)
+	field_updated.emit(int(spin_box.value) if as_integer else spin_box.value)
 
 
 func _on_value_changed(value: float) -> void:
-	field_changed.emit(value)
+	if as_integer:
+		field_changed.emit(int(value))
+	else:
+		field_changed.emit(value)

--- a/common/windows/graph_node_picker/graph_node_picker.gd
+++ b/common/windows/graph_node_picker/graph_node_picker.gd
@@ -37,6 +37,7 @@ func _on_enable_picker_mode(node: String = "", port: int = -1, mouse_pos = null,
 		else:
 			var mouse_position =  Vector2i(get_parent().get_global_mouse_position())
 			position = get_tree().get_root().position + mouse_position
+		current_screen = get_tree().get_root().current_screen
 		show()
 
 

--- a/common/windows/graph_node_picker/graph_node_picker.tscn
+++ b/common/windows/graph_node_picker/graph_node_picker.tscn
@@ -64,6 +64,7 @@ text = "Cancel"
 
 [connection signal="close_requested" from="." to="." method="_on_close_requested"]
 [connection signal="text_changed" from="PanelContainer/MarginContainer/VBoxContainer/SearchBar" to="PanelContainer/MarginContainer/VBoxContainer/Tree" method="_on_search_bar_text_changed"]
+[connection signal="item_activated" from="PanelContainer/MarginContainer/VBoxContainer/Tree" to="PanelContainer/MarginContainer/VBoxContainer/Tree" method="_on_item_activated"]
 [connection signal="item_selected" from="PanelContainer/MarginContainer/VBoxContainer/Tree" to="PanelContainer/MarginContainer/VBoxContainer/Tree" method="_on_item_selected"]
 [connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/CreateButton" to="." method="_on_create_button_pressed"]
 [connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/CreateButton" to="PanelContainer/MarginContainer/VBoxContainer/Tree" method="_create"]

--- a/common/windows/graph_node_picker/graph_node_tree.gd
+++ b/common/windows/graph_node_picker/graph_node_tree.gd
@@ -62,6 +62,15 @@ func _create() -> void:
 	GlobalSignal.emit("add_graph_node", [node_type, window])
 
 
+func _on_item_activated() -> void:
+	var item: TreeItem = get_selected()
+	if item.get_child_count() > 0:
+		item.collapsed = !item.collapsed
+	else:
+		_create()
+		window.close()
+
+
 func _on_item_selected() -> void:
 	var item: TreeItem = get_selected()
 	create_btn.disabled = item.get_child_count() > 0

--- a/common/windows/preview_window/preview_window.gd
+++ b/common/windows/preview_window/preview_window.gd
@@ -1,14 +1,29 @@
 extends Window
 
 
+@export var dns_checkbox: CheckBox
+@export var preferences_path: String = "user://preferences.save"
+
+var preferences: ConfigFile = ConfigFile.new()
+
+
 func _ready() -> void:
+	var error = preferences.load(preferences_path)
+	var do_not_show: bool
+	if error == OK:
+		do_not_show = preferences.get_value("Preview", "do_not_show", false)
+	
 	var version = ProjectSettings.get("application/config/version")
 	var is_pre_release = version.split("-").size() > 1
 	
-	visible = is_pre_release
+	visible = is_pre_release and not do_not_show
 	grab_focus()
 
+
 func _on_button_pressed() -> void:
+	if dns_checkbox:
+		preferences.set_value("Preview", "do_not_show", dns_checkbox.button_pressed)
+		preferences.save(preferences_path)
 	hide()
 
 

--- a/common/windows/preview_window/preview_window.gd
+++ b/common/windows/preview_window/preview_window.gd
@@ -2,28 +2,22 @@ extends Window
 
 
 @export var dns_checkbox: CheckBox
-@export var preferences_path: String = "user://preferences.save"
-
-var preferences: ConfigFile = ConfigFile.new()
 
 
 func _ready() -> void:
-	var error = preferences.load(preferences_path)
-	var do_not_show: bool
-	if error == OK:
-		do_not_show = preferences.get_value("Preview", "do_not_show", false)
-	
 	var version = ProjectSettings.get("application/config/version")
 	var is_pre_release = version.split("-").size() > 1
 	
+	var do_not_show = App.preferences.get_value("Preview", "do_not_show", false)
 	visible = is_pre_release and not do_not_show
 	grab_focus()
 
 
 func _on_button_pressed() -> void:
 	if dns_checkbox:
-		preferences.set_value("Preview", "do_not_show", dns_checkbox.button_pressed)
-		preferences.save(preferences_path)
+		var checked = dns_checkbox.button_pressed
+		App.preferences.set_value("Preview", "do_not_show", checked)
+		App.preferences.save(Constants.PREFERENCES_PATH)
 	hide()
 
 

--- a/common/windows/preview_window/preview_window.gd
+++ b/common/windows/preview_window/preview_window.gd
@@ -9,14 +9,18 @@ func _ready() -> void:
 	var is_pre_release = version.split("-").size() > 1
 	
 	var do_not_show = App.preferences.get_value("Preview", "do_not_show", false)
-	visible = is_pre_release and not do_not_show
+	var last_version = App.preferences.get_value("Preview", "last_version", "")
+	var is_new = version != last_version
+	visible = is_pre_release and (not do_not_show or is_new)
 	grab_focus()
 
 
 func _on_button_pressed() -> void:
 	if dns_checkbox:
 		var checked = dns_checkbox.button_pressed
+		var version = ProjectSettings.get("application/config/version")
 		App.preferences.set_value("Preview", "do_not_show", checked)
+		App.preferences.set_value("Preview", "last_version", version)
 		App.preferences.save(Constants.PREFERENCES_PATH)
 	hide()
 

--- a/common/windows/preview_window/preview_window.tscn
+++ b/common/windows/preview_window/preview_window.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://c7bl8kcyl4fxb" path="res://common/windows/preview_window/preview_window.gd" id="1_15o47"]
 
-[node name="PreviewWindow" type="Window"]
+[node name="PreviewWindow" type="Window" node_paths=PackedStringArray("dns_checkbox")]
 auto_translate_mode = 1
 transparent_bg = true
 initial_position = 2
@@ -18,6 +18,7 @@ transparent = true
 content_scale_mode = 2
 content_scale_aspect = 1
 script = ExtResource("1_15o47")
+dns_checkbox = NodePath("PanelContainer/MarginContainer/VBoxContainer/DNSChecker")
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 clip_children = 2
@@ -46,6 +47,10 @@ text = "[center][b]Monologue Preview[/b][/center]
 Monologue is in preview. If you encounter any bugs or issues, please report them on [url=https://github.com/atomic-junky/Monologue/]GitHub[/url] by creating an issue.
 
 Thank you very much for using Monologue!"
+
+[node name="DNSChecker" type="CheckBox" parent="PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Don't show this again"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2

--- a/common/windows/welcome_window/recent_file_container.gd
+++ b/common/windows/welcome_window/recent_file_container.gd
@@ -2,7 +2,7 @@ class_name RecentFilesContainer extends VBoxContainer
 
 
 @export var button_container: Control
-@export var save_path: String = "user://history.save"
+@export var save_path: String = Constants.HISTORY_PATH
 
 @onready var button_scene: PackedScene = preload("res://common/windows/welcome_window/recent_file_button.tscn")
 

--- a/logic/history/property_history.gd
+++ b/logic/history/property_history.gd
@@ -31,8 +31,7 @@ func change_properties() -> void:
 	for change in changes:
 		node[change.property].propagate(change.after)
 		node[change.property].value = change.after
-	
-	GlobalSignal.emit.call_deferred("refresh")
+	refresh_properties(node)
 
 
 func revert_properties() -> void:
@@ -41,10 +40,21 @@ func revert_properties() -> void:
 	for change in changes:
 		node[change.property].propagate(change.before)
 		node[change.property].value = change.before
-	
-	GlobalSignal.emit.call_deferred("refresh")
+	refresh_properties(node)
 
 
 func reset_language() -> void:
 	if GlobalVariables.language_switcher:
 		GlobalVariables.language_switcher.select_by_locale(locale, false)
+
+
+func refresh_properties(node: MonologueGraphNode) -> void:
+	var language = str(GlobalVariables.language_switcher.get_current_language())
+	var graph_node: MonologueGraphNode = null
+	var properties: PackedStringArray = []
+	# if language is the same, we can do partial refresh with given properties
+	# otherwise, full refresh so other controls can reflect the language change
+	if locale == language:
+		graph_node = node
+		properties = changes.map(func(c): return c.property)
+	GlobalSignal.emit.call_deferred("refresh", [graph_node, properties])

--- a/logic/history/property_history.gd
+++ b/logic/history/property_history.gd
@@ -26,21 +26,23 @@ func _init(graph: MonologueGraphEdit, path: NodePath,
 
 
 func change_properties() -> void:
+	var language := str(GlobalVariables.language_switcher.get_current_language())
 	reset_language()
 	var node: MonologueGraphNode = graph_edit.get_node(node_path)
 	for change in changes:
 		node[change.property].propagate(change.after)
 		node[change.property].value = change.after
-	refresh_properties(node)
+	refresh_properties(node, language)
 
 
 func revert_properties() -> void:
+	var language := str(GlobalVariables.language_switcher.get_current_language())
 	reset_language()
 	var node: MonologueGraphNode = graph_edit.get_node(node_path)
 	for change in changes:
 		node[change.property].propagate(change.before)
 		node[change.property].value = change.before
-	refresh_properties(node)
+	refresh_properties(node, language)
 
 
 func reset_language() -> void:
@@ -48,8 +50,7 @@ func reset_language() -> void:
 		GlobalVariables.language_switcher.select_by_locale(locale, false)
 
 
-func refresh_properties(node: MonologueGraphNode) -> void:
-	var language = str(GlobalVariables.language_switcher.get_current_language())
+func refresh_properties(node: MonologueGraphNode, language: String) -> void:
 	var graph_node: MonologueGraphNode = null
 	var properties: PackedStringArray = []
 	# if language is the same, we can do partial refresh with given properties

--- a/nodes/abstract_variable/abstract_variable.gd
+++ b/nodes/abstract_variable/abstract_variable.gd
@@ -80,7 +80,7 @@ func record_morph(new_value: Variant):
 	
 	# display integer without decimals
 	match get_variable_type(variable.value):
-		"Integer": new_value = int(new_value)
+		"Integer": new_value = int(new_value) if new_value else 0
 	get_value_label().text = str(new_value)
 
 

--- a/nodes/abstract_variable/abstract_variable.gd
+++ b/nodes/abstract_variable/abstract_variable.gd
@@ -77,6 +77,10 @@ func record_morph(new_value: Variant):
 			last_number = new_value
 		TYPE_STRING:
 			last_string = new_value
+	
+	# display integer without decimals
+	match get_variable_type(variable.value):
+		"Integer": new_value = int(new_value)
 	get_value_label().text = str(new_value)
 
 
@@ -97,7 +101,7 @@ func value_morph(selected_name: Variant = variable.value) -> void:
 			value.morph(SPINBOX)
 			value.value = int(last_number)
 			value.propagate(int(last_number), false)
-			get_value_label().text = str(last_number)
+			get_value_label().text = str(int(last_number))
 		"String":
 			operator.invoke("disable_items", [get_operator_disabler()])
 			value.morph(LINE)

--- a/nodes/random_node/random_node.gd
+++ b/nodes/random_node/random_node.gd
@@ -53,7 +53,7 @@ func add_output(data: Dictionary = {}) -> MonologueRandomOutput:
 	_output_references.append(output)
 	var line_instance := output_line.instantiate()
 	add_child(line_instance)
-	line_instance.update_label(str(output.weight.value) + "%")
+	line_instance.update_label(str(int(output.weight.value)) + "%")
 	
 	# if output was added from scratch, redistribute all equally
 	if not data:

--- a/nodes/wait_node/wait_node.gd
+++ b/nodes/wait_node/wait_node.gd
@@ -13,7 +13,7 @@ func _ready() -> void:
 
 
 func _on_wait_preview(value: Variant):
-	wait_label.text = str(value)
+	wait_label.text = str(int(value))
 
 
 func _update():

--- a/project.godot
+++ b/project.godot
@@ -38,8 +38,8 @@ Cursor="*res://autoloads/cursor.gd"
 
 [display]
 
-window/size/viewport_width=1600
-window/size/viewport_height=960
+window/size/viewport_width=1400
+window/size/viewport_height=800
 window/size/resizable=false
 window/size/transparent=true
 window/size/extend_to_title=true

--- a/scenes/main/graph.tscn
+++ b/scenes/main/graph.tscn
@@ -179,6 +179,7 @@ layout_mode = 2
 [node name="LanguageSwitcher" parent="MarginContainer/MainContainer/GraphEditsArea/ToolBarContainer/VBoxContainer/CenterContainer/ToolBar/Left/HBoxContainer" instance=ExtResource("6_nqv8k")]
 unique_name_in_owner = true
 layout_mode = 2
+disabled = true
 
 [node name="Right" type="PanelContainer" parent="MarginContainer/MainContainer/GraphEditsArea/ToolBarContainer/VBoxContainer/CenterContainer/ToolBar"]
 layout_mode = 2

--- a/scenes/main/monologue_control.gd
+++ b/scenes/main/monologue_control.gd
@@ -116,10 +116,13 @@ func refresh(node: MonologueGraphNode = null, affected_properties: PackedStringA
 	if node:
 		node.reload_preview()
 		if side_panel_node.visible:
+			# actual property value updates are handled by PropertyHistory
 			for property_name in affected_properties:
 				var field = side_panel_node.collapsibles.get(property_name)
 				if is_instance_valid(field):
 					field.open()
+		else:
+			node.get_graph_edit().set_selected(node)
 	# otherwise, remake the entire panel and refresh all node previews
 	else:
 		for each_node in graph_switcher.current.get_nodes():

--- a/scenes/main/monologue_control.gd
+++ b/scenes/main/monologue_control.gd
@@ -24,8 +24,6 @@ func _select_new_node() -> void:
 func _input(event):
 	if event.is_action_pressed("Save"):
 		save()
-	elif event.is_action_pressed("Add node"):
-		GlobalSignal.emit("enable_picker_mode")
 
 
 func _to_dict() -> Dictionary:

--- a/scenes/main/monologue_control.gd
+++ b/scenes/main/monologue_control.gd
@@ -24,6 +24,8 @@ func _select_new_node() -> void:
 func _input(event):
 	if event.is_action_pressed("Save"):
 		save()
+	elif event.is_action_pressed("Add node"):
+		GlobalSignal.emit("enable_picker_mode")
 
 
 func _to_dict() -> Dictionary:

--- a/scenes/main/monologue_control.gd
+++ b/scenes/main/monologue_control.gd
@@ -113,6 +113,8 @@ func refresh(node: MonologueGraphNode = null, affected_properties: PackedStringA
 	# if there is a given node, refresh only the parts that were specified
 	if node:
 		node.reload_preview()
+		if node is not OptionNode:
+			node._update.call_deferred()
 		if side_panel_node.visible:
 			# actual property value updates are handled by PropertyHistory
 			for property_name in affected_properties:
@@ -120,11 +122,13 @@ func refresh(node: MonologueGraphNode = null, affected_properties: PackedStringA
 				if is_instance_valid(field):
 					field.open()
 		else:
-			node.get_graph_edit().set_selected(node)
+			var choice = node.choice_node if node is OptionNode else node
+			node.get_graph_edit().set_selected(choice)
 	# otherwise, remake the entire panel and refresh all node previews
 	else:
 		for each_node in graph_switcher.current.get_nodes():
 			each_node.reload_preview()
+			#each_node._update.call_deferred()
 		if side_panel_node.visible:
 			var current_node = side_panel_node.selected_node
 			side_panel_node.on_graph_node_selected(current_node, true)

--- a/scenes/main/monologue_control.gd
+++ b/scenes/main/monologue_control.gd
@@ -111,11 +111,22 @@ func load_project(path: String, new_graph: bool = false) -> void:
 
 
 ## Reload the current graph edit and side panel values.
-func refresh() -> void:
-	for node in graph_switcher.current.get_nodes():
+func refresh(node: MonologueGraphNode = null, affected_properties: PackedStringArray = []) -> void:
+	# if there is a given node, refresh only the parts that were specified
+	if node:
 		node.reload_preview()
-	if side_panel_node.visible:
-		side_panel_node.on_graph_node_selected(side_panel_node.selected_node, true)
+		if side_panel_node.visible:
+			for property_name in affected_properties:
+				var field = side_panel_node.collapsibles.get(property_name)
+				if is_instance_valid(field):
+					field.open()
+	# otherwise, remake the entire panel and refresh all node previews
+	else:
+		for each_node in graph_switcher.current.get_nodes():
+			each_node.reload_preview()
+		if side_panel_node.visible:
+			var current_node = side_panel_node.selected_node
+			side_panel_node.on_graph_node_selected(current_node, true)
 
 
 func save():

--- a/scenes/splash/splash.gd
+++ b/scenes/splash/splash.gd
@@ -2,8 +2,8 @@ extends Control
 
 
 @export_file var load_scene: String
-@export var min_display_time: float = 2.0
-@export var after_blink_time: float = 1.0
+@export var min_display_time: float = 0.2
+@export var after_blink_time: float = 0.5
 
 @onready var timer = $tMinDisplayTime
 @onready var eye = $CenterContainer/AnimatedSprite2D

--- a/scenes/splash/splash.gd
+++ b/scenes/splash/splash.gd
@@ -6,7 +6,7 @@ extends Control
 @export var after_blink_time: float = 0.5
 
 @onready var timer = $tMinDisplayTime
-@onready var eye = $CenterContainer/AnimatedSprite2D
+@onready var eye = $CenterContainer/TextureRect/AnimatedSprite2D
 
 
 func _ready() -> void:

--- a/scenes/splash/splash.tscn
+++ b/scenes/splash/splash.tscn
@@ -63,8 +63,8 @@ texture = ExtResource("2_rikux")
 expand_mode = 5
 stretch_mode = 5
 
-[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="CenterContainer"]
-position = Vector2(559, 479)
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="CenterContainer/TextureRect"]
+position = Vector2(142, 40)
 scale = Vector2(0.263, 0.26)
 sprite_frames = SubResource("SpriteFrames_tj644")
 animation = &"blink"


### PR DESCRIPTION
This PR makes the user experience more snappy in general:
- Reduce splash screen time; I think forcing the user to wait a minimum of 3 seconds in total is too long, so now it's about 1 second.
- Preview window can now be dismissed with the "do not show again" checkbox so that it doesn't keep popping up. When the version changes, it should show again because the version is saved in file as well, so there will be a check.
- Resolve #52 by remembering the focus via NodePath before the side panel refresh, then grab focus on the control with the same NodePath after refresh. It's a little hacky but it feels better to click between different fields now. We can think about fields for Characters at a later stage.
- Allowed `Shift + A` to open the Add Node window. Double-click now work to collapse/uncollapse and select nodes for creation.
- Language switcher dropdown will now close when user clicks on graph edit, feels more natural.